### PR TITLE
Make Tapyrus-seeder Network id aware. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ VOLUME ${APP_DIRECTORY}
 
 EXPOSE 53
 
-ENTRYPOINT ["dnsseed", "--testnet", "-m", "nakajo@chaintope.com"]
+ENTRYPOINT ["dnsseed", "-i", "1939510133", "-m", "nakajo@chaintope.com"]

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-CXXFLAGS = -O3 -g0 -march=native
-LDFLAGS = $(CXXFLAGS)
+CXXFLAGS = -march=native -I/usr/local/opt/openssl/include
+LDFLAGS = $(CXXFLAGS) -L/usr/local/opt/openssl/lib
 
-dnsseed: dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o
-	g++ -pthread $(LDFLAGS) -o dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o -lcrypto
+ifeq (${DEBUG}, y)
+  CXXFLAGS += -O0 -g3 -DDEBUG
+else
+  CXXFAGS += -O3 -g0
+endif
 
-%.o: %.cpp bitcoin.h netbase.h protocol.h db.h serialize.h uint256.h util.h
+dnsseed: dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o
+	g++ -pthread $(LDFLAGS) -o dnsseed dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o -lcrypto
+
+%.o: %.cpp *.h
 	g++ -std=c++11 -pthread $(CXXFLAGS) -Wall -Wno-unused -Wno-sign-compare -Wno-reorder -Wno-comment -c -o $@ $<
-
-dns.o: dns.c
-	gcc -pthread -std=c99 $(CXXFLAGS) dns.c -Wall -c -o dns.o
-
-%.o: %.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-CXXFLAGS = -march=native -I/usr/local/opt/openssl/include
-LDFLAGS = $(CXXFLAGS) -L/usr/local/opt/openssl/lib
+# export OPENSSL_PREFIX=/usr/local/opt/openssl
+# make
+#   or
+# make OPENSSL_PREFIX=/usr/local/opt/openssl
+CXXFLAGS = -march=native -I${OPENSSL_PREFIX}/include
+LDFLAGS = $(CXXFLAGS) -L${OPENSSL_PREFIX}/lib
 
+# make DEBUG=y OPENSSL_PREFIX=/usr/local/opt/openssl
 ifeq (${DEBUG}, y)
   CXXFLAGS += -O0 -g3 -DDEBUG
 else

--- a/bitcoin.h
+++ b/bitcoin.h
@@ -1,8 +1,0 @@
-#ifndef _BITCOIN_H_
-#define _BITCOIN_H_ 1
-
-#include "protocol.h"
-
-bool TestNode(const CService &cip, int &ban, int &client, std::string &clientSV, int &blocks, std::vector<CAddress>* vAddr);
-
-#endif

--- a/db.h
+++ b/db.h
@@ -101,13 +101,13 @@ public:
   }
   
   bool IsGood() const {
-      printf("service=%d\n", !(services & NODE_NETWORK));
+  //printf("service=%d\n", !(services & NODE_NETWORK));
     if (!(services & NODE_NETWORK)) return false;
     if (!ip.IsRoutable()) return false;
     if (clientVersion && clientVersion < REQUIRE_VERSION) return false;
     if (blocks && blocks < GetRequireHeight()) return false;
 
-    printf("node check all pass: total=%d, success=%d\n", total, success);
+    //printf("node check all pass: total=%d, success=%d\n", total, success);
     if (total <= 3 && success * 2 >= total) return true;
 
     if (stat2H.reliability > 0.85 && stat2H.count > 2) return true;
@@ -139,7 +139,7 @@ public:
   friend class CAddrDb;
   
   IMPLEMENT_SERIALIZE (
-    unsigned char version = 4;
+    unsigned char version = 0;
     READWRITE(version);
     READWRITE(ip);
     READWRITE(services);
@@ -153,20 +153,13 @@ public:
       READWRITE(stat8H);
       READWRITE(stat1D);
       READWRITE(stat1W);
-      if (version >= 1)
-          READWRITE(stat1M);
-      else
-          if (!fWrite)
-              *((CAddrStat*)(&stat1M)) = stat1W;
+      READWRITE(stat1M);
       READWRITE(total);
       READWRITE(success);
       READWRITE(clientVersion);
-      if (version >= 2)
-          READWRITE(clientSubVersion);
-      if (version >= 3)
-          READWRITE(blocks);
-      if (version >= 4)
-          READWRITE(ourLastSuccess);
+      READWRITE(clientSubVersion);
+      READWRITE(blocks);
+      READWRITE(ourLastSuccess);
     }
   )
 };

--- a/db.h
+++ b/db.h
@@ -101,15 +101,13 @@ public:
   }
   
   bool IsGood() const {
-//      printf("port=%d, default port=%d\n", ip.GetPort(), GetDefaultPort());
-    if (ip.GetPort() != GetDefaultPort()) return false;
-//      printf("service=%d\n", !(services & NODE_NETWORK));
+      printf("service=%d\n", !(services & NODE_NETWORK));
     if (!(services & NODE_NETWORK)) return false;
     if (!ip.IsRoutable()) return false;
     if (clientVersion && clientVersion < REQUIRE_VERSION) return false;
     if (blocks && blocks < GetRequireHeight()) return false;
 
-//    printf("node check all pass: total=%d, success=%d\n", total, success);
+    printf("node check all pass: total=%d, success=%d\n", total, success);
     if (total <= 3 && success * 2 >= total) return true;
 
     if (stat2H.reliability > 0.85 && stat2H.count > 2) return true;

--- a/db.h
+++ b/db.h
@@ -202,6 +202,7 @@ struct CServiceResult {
 class CAddrDb {
 private:
   mutable CCriticalSection cs;
+  int networkid;
   int nId; // number of address id's
   std::map<int, CAddrInfo> idToInfo; // map address id to address info (b,c,d,e)
   std::map<CService, int> ipToId; // map ip to id (b,c,d,e)
@@ -231,7 +232,8 @@ public:
       stats.nTracked = ourId.size();
       stats.nGood = goodId.size();
       stats.nNew = unkId.size();
-      stats.nAge = ourId.size() ? time(NULL) - idToInfo[ourId[0]].ourLastTry : 0;
+      if(ourId.size())
+        stats.nAge = time(NULL) - idToInfo[ourId[0]].ourLastTry;
     }
   }
 
@@ -257,6 +259,7 @@ public:
   // serialization code
   // format:
   //   nVersion (0 for now)
+  //   networkid
   //   n (number of ips in (b,c,d))
   //   CAddrInfo[n]
   //   banned
@@ -265,6 +268,7 @@ public:
   IMPLEMENT_SERIALIZE (({
     int nVersion = 0;
     READWRITE(nVersion);
+    READWRITE(networkid);
     SHARED_CRITICAL_BLOCK(cs) {
       if (fWrite) {
         CAddrDb *db = const_cast<CAddrDb*>(this);

--- a/db.h
+++ b/db.h
@@ -12,9 +12,9 @@
 
 #define MIN_RETRY 60
 
-#define REQUIRE_VERSION 70001
+#define REQUIRE_VERSION 10000
 
-static inline int GetRequireHeight(const bool testnet = fTestNet)
+static inline int GetRequireHeight()
 {
     return 1;
 }
@@ -122,7 +122,6 @@ public:
   }
   int GetBanTime() const {
     if (IsGood()) return 0;
-    if (clientVersion && clientVersion < 31900) { return 604800; }
     if (stat1M.reliability - stat1M.weight + 1.0 < 0.15 && stat1M.count > 32) { return 30*86400; }
     if (stat1W.reliability - stat1W.weight + 1.0 < 0.10 && stat1W.count > 16) { return 7*86400; }
     if (stat1D.reliability - stat1D.weight + 1.0 < 0.05 && stat1D.count > 8) { return 1*86400; }
@@ -234,7 +233,7 @@ public:
       stats.nTracked = ourId.size();
       stats.nGood = goodId.size();
       stats.nNew = unkId.size();
-      stats.nAge = time(NULL) - idToInfo[ourId[0]].ourLastTry;
+      stats.nAge = ourId.size() ? time(NULL) - idToInfo[ourId[0]].ourLastTry : 0;
     }
   }
 

--- a/dns.cpp
+++ b/dns.cpp
@@ -16,17 +16,11 @@
 
 #define BUFLEN 512
 
-#if defined IP_RECVDSTADDR
+#if defined(IP_RECVDSTADDR)
 # define DSTADDR_SOCKOPT IP_RECVDSTADDR
 # define DSTADDR_DATASIZE (CMSG_SPACE(sizeof(struct in6_addr)))
 # define dstaddr(x) (CMSG_DATA(x))
-#elif defined IPV6_PKTINFO
-struct in6_pktinfo
-  {
-    struct in6_addr ipi6_addr;	/* src/dst IPv6 address */
-    unsigned int ipi6_ifindex;	/* send/recv interface index */
-  };
-
+#elif defined(IPV6_PKTINFO)
 # define DSTADDR_SOCKOPT IPV6_PKTINFO
 # define DSTADDR_DATASIZE (CMSG_SPACE(sizeof(struct in6_pktinfo)))
 # define dstaddr(x) (&(((struct in6_pktinfo *)(CMSG_DATA(x)))->ipi6_addr))
@@ -109,7 +103,7 @@ int static parse_name(const unsigned char **inpos, const unsigned char *inend, c
 // -3: two subsequent dots
 int static write_name(unsigned char** outpos, const unsigned char *outend, const char *name, int offset) {
   while (*name != 0) {
-    char *dot = strchr(name, '.');
+    const char *dot = strchr(name, '.');
     const char *fin = dot;
     if (!dot) fin = name + strlen(name);
     if (fin - name > 63) return -1;
@@ -138,16 +132,21 @@ int static write_record(unsigned char** outpos, const unsigned char *outend, con
   int error = 0;
   // name
   int ret = write_name(outpos, outend, name, offset);
-  if (ret) { error = ret; goto error; }
-  if (outend - *outpos < 8) { error = -4; goto error; }
-  // type
-  *((*outpos)++) = typ >> 8; *((*outpos)++) = typ & 0xFF;
-  // class
-  *((*outpos)++) = cls >> 8; *((*outpos)++) = cls & 0xFF;
-  // ttl
-  *((*outpos)++) = (ttl >> 24) & 0xFF; *((*outpos)++) = (ttl >> 16) & 0xFF; *((*outpos)++) = (ttl >> 8) & 0xFF; *((*outpos)++) = ttl & 0xFF;
-  return 0;
-error:
+  if (ret) {
+    error = ret;
+  } else {
+    if (outend - *outpos < 8) {
+      error = -4;
+    } else {
+      // type
+      *((*outpos)++) = typ >> 8; *((*outpos)++) = typ & 0xFF;
+      // class
+      *((*outpos)++) = cls >> 8; *((*outpos)++) = cls & 0xFF;
+      // ttl
+      *((*outpos)++) = (ttl >> 24) & 0xFF; *((*outpos)++) = (ttl >> 16) & 0xFF; *((*outpos)++) = (ttl >> 8) & 0xFF; *((*outpos)++) = ttl & 0xFF;
+      return 0;
+    }
+  }
   *outpos = oldpos;
   return error;
 }
@@ -160,14 +159,16 @@ int static write_record_a(unsigned char** outpos, const unsigned char *outend, c
   int error = 0;
   int ret = write_record(outpos, outend, name, offset, TYPE_A, cls, ttl);
   if (ret) return ret;
-  if (outend - *outpos < 6) { error = -5; goto error; }
-  // rdlength
-  *((*outpos)++) = 0; *((*outpos)++) = 4;
-  // rdata
-  for (int i=0; i<4; i++)
-    *((*outpos)++) = ip->data.v4[i];
-  return 0;
-error:
+  if (outend - *outpos < 6) {
+    error = -5;
+  } else {
+    // rdlength
+    *((*outpos)++) = 0; *((*outpos)++) = 4;
+    // rdata
+    for (int i=0; i<4; i++)
+      *((*outpos)++) = ip->data.v4[i];
+    return 0;
+  }
   *outpos = oldpos;
   return error;
 }
@@ -179,61 +180,90 @@ int static write_record_aaaa(unsigned char** outpos, const unsigned char *outend
   int error = 0;
   int ret = write_record(outpos, outend, name, offset, TYPE_AAAA, cls, ttl);
   if (ret) return ret;
-  if (outend - *outpos < 6) { error = -5; goto error; }
-  // rdlength
-  *((*outpos)++) = 0; *((*outpos)++) = 16;
-  // rdata
-  for (int i=0; i<16; i++)
-    *((*outpos)++) = ip->data.v6[i];
-  return 0;
-error:
+  if (outend - *outpos < 6) {
+    error = -5;
+  } else {
+    // rdlength
+    *((*outpos)++) = 0; *((*outpos)++) = 16;
+    // rdata
+    for (int i=0; i<16; i++)
+      *((*outpos)++) = ip->data.v6[i];
+    return 0;
+  }
   *outpos = oldpos;
   return error;
 }
 
-int static write_record_ns(unsigned char** outpos, const unsigned char *outend, char *name, int offset, dns_class cls, int ttl, const char *ns) {
+int static write_record_ns(unsigned char** outpos, const unsigned char *outend, const char *name, int offset, dns_class cls, int ttl, const char *ns) {
   unsigned char *oldpos = *outpos;
   int ret = write_record(outpos, outend, name, offset, TYPE_NS, cls, ttl);
   if (ret) return ret;
   int error = 0;
-  if (outend - *outpos < 2) { error = -5; goto error; }
-  (*outpos) += 2;
-  unsigned char *curpos = *outpos;
-  ret = write_name(outpos, outend, ns, -1);
-  if (ret) { error = ret; goto error; }
-  curpos[-2] = (*outpos - curpos) >> 8;
-  curpos[-1] = (*outpos - curpos) & 0xFF;
-  return 0;
-error:
+  if (outend - *outpos < 2) {
+    error = -5;
+  } else {
+    (*outpos) += 2;
+    unsigned char *curpos = *outpos;
+    ret = write_name(outpos, outend, ns, -1);
+    if (ret) {
+      error = ret;
+    } else {
+      curpos[-2] = (*outpos - curpos) >> 8;
+      curpos[-1] = (*outpos - curpos) & 0xFF;
+      return 0;
+    }
+  }
   *outpos = oldpos;
   return error;
 }
 
-int static write_record_soa(unsigned char** outpos, const unsigned char *outend, char *name, int offset, dns_class cls, int ttl, const char* mname, const char *rname,
+int static write_record_soa(unsigned char** outpos, const unsigned char *outend, const char *name, int offset, dns_class cls, int ttl, const char* mname, const char *rname,
                      uint32_t serial, uint32_t refresh, uint32_t retry, uint32_t expire, uint32_t minimum) {
   unsigned char *oldpos = *outpos;
   int ret = write_record(outpos, outend, name, offset, TYPE_SOA, cls, ttl);
   if (ret) return ret;
   int error = 0;
-  if (outend - *outpos < 2) { error = -5; goto error; }
-  (*outpos) += 2;
-  unsigned char *curpos = *outpos;
-  ret = write_name(outpos, outend, mname, -1);
-  if (ret) { error = ret; goto error; }
-  ret = write_name(outpos, outend, rname, -1);
-  if (ret) { error = ret; goto error; }
-  if (outend - *outpos < 20) { error = -5; goto error; }
-  *((*outpos)++) = (serial  >> 24) & 0xFF; *((*outpos)++) = (serial  >> 16) & 0xFF; *((*outpos)++) = (serial  >> 8) & 0xFF; *((*outpos)++) = serial  & 0xFF;
-  *((*outpos)++) = (refresh >> 24) & 0xFF; *((*outpos)++) = (refresh >> 16) & 0xFF; *((*outpos)++) = (refresh >> 8) & 0xFF; *((*outpos)++) = refresh & 0xFF;
-  *((*outpos)++) = (retry   >> 24) & 0xFF; *((*outpos)++) = (retry   >> 16) & 0xFF; *((*outpos)++) = (retry   >> 8) & 0xFF; *((*outpos)++) = retry   & 0xFF;
-  *((*outpos)++) = (expire  >> 24) & 0xFF; *((*outpos)++) = (expire  >> 16) & 0xFF; *((*outpos)++) = (expire  >> 8) & 0xFF; *((*outpos)++) = expire  & 0xFF;
-  *((*outpos)++) = (minimum >> 24) & 0xFF; *((*outpos)++) = (minimum >> 16) & 0xFF; *((*outpos)++) = (minimum >> 8) & 0xFF; *((*outpos)++) = minimum & 0xFF;
-  curpos[-2] = (*outpos - curpos) >> 8;
-  curpos[-1] = (*outpos - curpos) & 0xFF;
-  return 0;
-error:
+  if (outend - *outpos < 2) {
+    error = -5;
+  } else {
+    (*outpos) += 2;
+    unsigned char *curpos = *outpos;
+    ret = write_name(outpos, outend, mname, -1);
+    if (ret) {
+      error = ret;
+    } else {
+      ret = write_name(outpos, outend, rname, -1);
+      if (ret) {
+        error = ret;
+      } else {
+        if (outend - *outpos < 20) {
+          error = -5;
+        } else {
+          *((*outpos)++) = (serial  >> 24) & 0xFF; *((*outpos)++) = (serial  >> 16) & 0xFF; *((*outpos)++) = (serial  >> 8) & 0xFF; *((*outpos)++) = serial  & 0xFF;
+          *((*outpos)++) = (refresh >> 24) & 0xFF; *((*outpos)++) = (refresh >> 16) & 0xFF; *((*outpos)++) = (refresh >> 8) & 0xFF; *((*outpos)++) = refresh & 0xFF;
+          *((*outpos)++) = (retry   >> 24) & 0xFF; *((*outpos)++) = (retry   >> 16) & 0xFF; *((*outpos)++) = (retry   >> 8) & 0xFF; *((*outpos)++) = retry   & 0xFF;
+          *((*outpos)++) = (expire  >> 24) & 0xFF; *((*outpos)++) = (expire  >> 16) & 0xFF; *((*outpos)++) = (expire  >> 8) & 0xFF; *((*outpos)++) = expire  & 0xFF;
+          *((*outpos)++) = (minimum >> 24) & 0xFF; *((*outpos)++) = (minimum >> 16) & 0xFF; *((*outpos)++) = (minimum >> 8) & 0xFF; *((*outpos)++) = minimum & 0xFF;
+          curpos[-2] = (*outpos - curpos) >> 8;
+          curpos[-1] = (*outpos - curpos) & 0xFF;
+          return 0;
+        }
+      }
+    }
+  }
   *outpos = oldpos;
   return error;
+}
+
+static ssize_t set_error(unsigned char* outbuf, int error) {
+  // set error
+  outbuf[3] |= error & 0xF;
+  // set counts
+  outbuf[4] = 0;  outbuf[5] = 0;
+  outbuf[6] = 0;  outbuf[7] = 0;
+  outbuf[8] = 0;  outbuf[9] = 0;
+  outbuf[10] = 0; outbuf[11] = 0;
+  return 12;
 }
 
 ssize_t static dnshandle(dns_opt_t *opt, const unsigned char *inbuf, size_t insize, unsigned char* outbuf) {
@@ -249,27 +279,27 @@ ssize_t static dnshandle(dns_opt_t *opt, const unsigned char *inbuf, size_t insi
   // clear error
   outbuf[3] &= ~15;
   // check qr
-  if (inbuf[2] & 128) { /* printf("Got response?\n"); */ error = 1; goto error; }
+  if (inbuf[2] & 128) return set_error(outbuf, 1); /* printf("Got response?\n"); */
   // check opcode
-  if (((inbuf[2] & 120) >> 3) != 0) { /* printf("Opcode nonzero?\n"); */ error = 4; goto error; }
+  if (((inbuf[2] & 120) >> 3) != 0) return set_error(outbuf, 1); /* printf("Opcode nonzero?\n"); */
   // unset TC
   outbuf[2] &= ~2;
   // unset RA
   outbuf[3] &= ~128;
   // check questions
   int nquestion = (inbuf[4] << 8) + inbuf[5];
-  if (nquestion == 0) { /* printf("No questions?\n"); */ error = 0; goto error; }
-  if (nquestion > 1) { /* printf("Multiple questions %i?\n", nquestion); */ error = 4; goto error; }
+  if (nquestion == 0) return set_error(outbuf, 0); /* printf("No questions?\n"); */
+  if (nquestion > 1) return set_error(outbuf, 4); /* printf("Multiple questions %i?\n", nquestion); */
   const unsigned char *inpos = inbuf + 12;
   const unsigned char *inend = inbuf + insize;
   char name[256];
   int offset = inpos - inbuf;
   int ret = parse_name(&inpos, inend, inbuf, name, 256);
-  if (ret == -1) { error = 1; goto error; }
-  if (ret == -2) { error = 5; goto error; }
+  if (ret == -1) return set_error(outbuf, 1);
+  if (ret == -2) return set_error(outbuf, 5);
   int namel = strlen(name), hostl = strlen(opt->host);
-  if (strcasecmp(name, opt->host) && (namel<hostl+2 || name[namel-hostl-1]!='.' || strcasecmp(name+namel-hostl,opt->host))) { error = 5; goto error; }
-  if (inend - inpos < 4) { error = 1; goto error; }
+  if (strcasecmp(name, opt->host) && (namel<hostl+2 || name[namel-hostl-1]!='.' || strcasecmp(name+namel-hostl,opt->host))) return set_error(outbuf, 5);
+  if (inend - inpos < 4) return set_error(outbuf, 1);
   // copy question to output
   memcpy(outbuf+12, inbuf+12, inpos+4 - (inbuf+12));
   // set counts
@@ -357,8 +387,7 @@ ssize_t static dnshandle(dns_opt_t *opt, const unsigned char *inbuf, size_t insi
     // response. If we replied with NS above we'd create a bad horizontal
     // referral loop, as the NS response indicates where the resolver should
     // try next.
-    // TODO: should revert when network is stable.
-    int ret2 = write_record_soa(&outpos, outend, "", offset, CLASS_IN, opt->nsttl, opt->ns, opt->mbox, time(NULL), 300, 180, 604800, 120);
+    int ret2 = write_record_soa(&outpos, outend, "", offset, CLASS_IN, opt->nsttl, opt->ns, opt->mbox, time(NULL), 604800, 86400, 2592000, 604800);
 //    printf("wrote SOA record: %i\n", ret2);
     if (!ret2) { outbuf[9]++; }
   }
@@ -367,15 +396,6 @@ ssize_t static dnshandle(dns_opt_t *opt, const unsigned char *inbuf, size_t insi
   outbuf[2] |= 4;
   
   return outpos - outbuf;
-error:
-  // set error
-  outbuf[3] |= error & 0xF;
-  // set counts
-  outbuf[4] = 0;  outbuf[5] = 0;
-  outbuf[6] = 0;  outbuf[7] = 0;
-  outbuf[8] = 0;  outbuf[9] = 0;
-  outbuf[10] = 0; outbuf[11] = 0;
-  return 12;
 }
 
 static int listenSocket = -1;

--- a/dns.h
+++ b/dns.h
@@ -3,15 +3,15 @@
 
 #include <stdint.h>
 
-typedef struct {
+struct addr_t {
     int v;
     union {
        unsigned char v4[4];
        unsigned char v6[16];
     } data;
-} addr_t;
+};
 
-typedef struct {
+struct dns_opt_t {
   int port;
   int datattl;
   int nsttl;
@@ -21,8 +21,8 @@ typedef struct {
   int (*cb)(void *opt, char *requested_hostname, addr_t *addr, int max, int ipv4, int ipv6);
   // stats
   uint64_t nRequests;
-} dns_opt_t;
+};
 
-extern int dnsserver(dns_opt_t *opt);
+int dnsserver(dns_opt_t *opt);
 
 #endif

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -22,21 +22,18 @@ static const char* ppszTypeName[] =
     "block",
 };
 
-// 01FFF000
-unsigned char pchMessageStart[4] = { 0x01, 0xff, 0xf0, 0x00 };
-
-CMessageHeader::CMessageHeader()
+CMessageHeader::CMessageHeader(const char* messageStart)
 {
-    memcpy(pchMessageStart, ::pchMessageStart, sizeof(pchMessageStart));
+    memcpy(pchMessageStart, messageStart, sizeof(pchMessageStart));
     memset(pchCommand, 0, sizeof(pchCommand));
     pchCommand[1] = 1;
     nMessageSize = -1;
     nChecksum = 0;
 }
 
-CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn)
+CMessageHeader::CMessageHeader(const char* pszCommand, const char* messageStart, unsigned int nMessageSizeIn)
 {
-    memcpy(pchMessageStart, ::pchMessageStart, sizeof(pchMessageStart));
+    memcpy(pchMessageStart, messageStart, sizeof(pchMessageStart));
     strncpy(pchCommand, pszCommand, COMMAND_SIZE);
     nMessageSize = nMessageSizeIn;
     nChecksum = 0;
@@ -50,10 +47,10 @@ std::string CMessageHeader::GetCommand() const
         return std::string(pchCommand, pchCommand + COMMAND_SIZE);
 }
 
-bool CMessageHeader::IsValid() const
+bool CMessageHeader::IsValid(const char* messageStart) const
 {
     // Check start string
-    if (memcmp(pchMessageStart, ::pchMessageStart, sizeof(pchMessageStart)) != 0)
+    if (memcmp(pchMessageStart, messageStart, sizeof(pchMessageStart)) != 0)
         return false;
 
     // Check the command string for errors

--- a/protocol.h
+++ b/protocol.h
@@ -15,10 +15,9 @@
 #include <string>
 #include "uint256.h"
 
-extern bool fTestNet;
-static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
+static inline unsigned short GetDefaultPort()
 {
-    return testnet ? 12357 : 2357;
+    return 2357;
 }
 
 //
@@ -28,30 +27,27 @@ static inline unsigned short GetDefaultPort(const bool testnet = fTestNet)
 //  (4) size
 //  (4) checksum
 
-extern unsigned char pchMessageStart[4];
-
 class CMessageHeader
 {
     public:
-        CMessageHeader();
-        CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn);
+        CMessageHeader(const char* messageStart);
+        CMessageHeader(const char* pszCommand, const char* messageStart, unsigned int nMessageSizeIn);
 
         std::string GetCommand() const;
-        bool IsValid() const;
+        bool IsValid(const char* messageStart) const;
 
         IMPLEMENT_SERIALIZE
             (
              READWRITE(FLATDATA(pchMessageStart));
              READWRITE(FLATDATA(pchCommand));
              READWRITE(nMessageSize);
-             if (nVersion >= 209)
              READWRITE(nChecksum);
             )
 
     // TODO: make private (improves encapsulation)
     public:
         enum { COMMAND_SIZE=12 };
-        char pchMessageStart[sizeof(::pchMessageStart)];
+        char pchMessageStart[4];
         char pchCommand[COMMAND_SIZE];
         unsigned int nMessageSize;
         unsigned int nChecksum;
@@ -77,9 +73,9 @@ class CAddress : public CService
              if (fRead)
                  pthis->Init();
              if (nType & SER_DISK)
-             READWRITE(nVersion);
-             if ((nType & SER_DISK) || (nVersion >= 31402 && !(nType & SER_GETHASH)))
-             READWRITE(nTime);
+                READWRITE(nVersion);
+             if ((nType & SER_DISK) || (nType & SER_NETWORK) && nVersion > INIT_PROTO_VERSION)
+                READWRITE(nTime);
              READWRITE(nServices);
              READWRITE(*pip);
             )

--- a/protocol.h
+++ b/protocol.h
@@ -15,10 +15,7 @@
 #include <string>
 #include "uint256.h"
 
-static inline unsigned short GetDefaultPort()
-{
-    return 2357;
-}
+static const int TAPYRUS_DEFAULT_PORT = 2357;
 
 //
 // Message header

--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,10 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 60000;
+static const int PROTOCOL_VERSION = 10000;
+
+//! initial proto version, to be increased after version/verack negotiation
+static const int INIT_PROTO_VERSION = 1227;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB

--- a/tapyrus.h
+++ b/tapyrus.h
@@ -1,0 +1,8 @@
+#ifndef _TAPYRUS_H_
+#define _TAPYRUS_H_ 1
+
+#include "protocol.h"
+
+bool TestNode(const CService &cip, int &ban, int &client, std::string &clientSV, int &blocks, std::vector<CAddress>* vAddr, int networkid);
+
+#endif


### PR DESCRIPTION
**New parameters:**
Added _-n/networkid_ argument to configure network id. All threads take networked as an argument. Dumping thread created a file with networkid. Crawler thread used magic bytes created using the networkid.

Added _-s/seed_ argument to configure additional seeder nodes. Seeder thread takes the list of seeders as an argument. It is mandatory to configure at least one seeder.

**Other changes:**
Updated default port, PROTOCOL_VERSION and CLIENT_VERSION to match Tapyrus. 
Renamed "bitcoin" to "tapyrus" wherever applicable.
Added DEBUG mode with low optimisation to enable debugging. 
Merged commit 529a667 from sipa/bitcoin-seeder - converting dns.c to dns.cpp
