### PR TITLE
Service multiple Tapyrus networks from a single Tapyrus Seeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.o
-dnsseed*
-dnsstats.log
+tapyrusseed*
+tapyrusdnsstats.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN make
 
 FROM alpine:3.7
 
-COPY --from=seed-build /src/dnsseed /usr/local/bin/dnsseed
+COPY --from=seed-build /src/tapyrusseed /usr/local/bin/tapyrusseed
 
 RUN apk --no-cache add \
     libcrypto1.0 \
@@ -31,4 +31,4 @@ VOLUME ${APP_DIRECTORY}
 
 EXPOSE 53
 
-ENTRYPOINT ["dnsseed", "-i", "1939510133", "-m", "nakajo@chaintope.com"]
+ENTRYPOINT ["tapyrusseed", "-i", "1939510133", "-s", "1939510133:seed.tapyrus.dev.chaintope.com", "-m", "nakajo@chaintope.com"]

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ else
   CXXFAGS += -O3 -g0
 endif
 
-dnsseed: dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o
-	g++ -pthread $(LDFLAGS) -o dnsseed dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o -lcrypto
+tapyrusseed: dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o
+	g++ -pthread $(LDFLAGS) -o tapyrusseed dns.o tapyrus.o netbase.o protocol.o db.o main.o util.o -lcrypto
 
 %.o: %.cpp *.h
 	g++ -std=c++11 -pthread $(CXXFLAGS) -Wall -Wno-unused -Wno-sign-compare -Wno-reorder -Wno-comment -c -o $@ $<

--- a/README
+++ b/README
@@ -11,7 +11,7 @@ Features:
 * keeps statistics over (exponential) windows of 2 hours, 8 hours,
   1 day and 1 week, to base decisions on.
 * very low memory (a few tens of megabytes) and cpu requirements.
-* crawlers can monitor multiple networks and run in parallel (by default 94 threads simultaneously).
+* crawlers can monitor multiple networks and run in parallel (by default 96 threads simultaneously).
 
 REQUIREMENTS
 ------------
@@ -47,6 +47,8 @@ Multiple initial seeders for each networks can be configured using multiple -s
 The initial seed node may be another Tapyrus seeder or a Tapyrus core node
 
 ./tapyrusseed -i <network_id> -s <network_id>:<tapyrus_seeder_name> -s <network_id>:<ip_address>:<tapyrus_core_port>
+
+When parsing of an initial seeder parameter fails it is ignored and only valid parameters are used.
 
 If you want the DNS server to report SOA records, please provide an
 e-mail address (with the @ part replaced by .) using -m.

--- a/README
+++ b/README
@@ -1,18 +1,17 @@
-bitcoin-seeder
+Tapyrus-seeder
 ==============
 
-Bitcoin-seeder is a crawler for the Bitcoin network, which exposes a list
+Tapyrus-seeder is a crawler for the Tapyrus network, which exposes a list
 of reliable nodes via a built-in DNS server.
 
 Features:
 * regularly revisits known nodes to check their availability
 * bans nodes after enough failures, or bad behaviour
-* accepts nodes down to v0.3.19 to request new IP addresses from,
-  but only reports good post-v0.3.24 nodes.
+* accepts nodes down to v0.3.0 to request new IP addresses
 * keeps statistics over (exponential) windows of 2 hours, 8 hours,
   1 day and 1 week, to base decisions on.
 * very low memory (a few tens of megabytes) and cpu requirements.
-* crawlers run in parallel (by default 24 threads simultaneously).
+* crawlers can monitor multiple networks and run in parallel (by default 94 threads simultaneously).
 
 REQUIREMENTS
 ------------
@@ -22,18 +21,32 @@ $ sudo apt-get install build-essential libboost-all-dev libssl-dev
 USAGE
 -----
 
-Assuming you want to run a dns seed on dnsseed.example.com, you will
+Assuming you want to run a dns seed on tapyrusseed.example.com, you will
 need an authorative NS record in example.com's domain record, pointing
 to for example vps.example.com:
 
-$ dig -t NS dnsseed.example.com
+$ dig -t NS tapyrusseed.example.com
 
 ;; ANSWER SECTION
-dnsseed.example.com.   86400    IN      NS     vps.example.com.
+tapyrusseed.example.com.   86400    IN      NS     vps.example.com.
 
-On the system vps.example.com, you can now run dnsseed:
+On the system vps.example.com, you can now run tapyrusseed:
 
-./dnsseed -h dnsseed.example.com -n vps.example.com
+./tapyrusseed -i <network_id> -s <network_id>:<initial_seeder> -h tapyrusseed.example.com -n vps.example.com
+
+-i is the network_id
+-s is the name of the initial seeder
+
+When Tapyrus seeder is started for the first time, it queries the initial_seeder to get the addresses of some nodes in each network and builds it own file. After this the seeder can be restarted without initial seeder(-s) argument.
+
+Multiple networks can be supported by using multiple -i
+Multiple initial seeders for each networks can be configured using multiple -s
+
+./tapyrusseed -i <network_id1> -i <network_id2> -i <network_id3> -s <network_id1>:<initial_seeder1>  -s <network_id1>:<initial_seeder2> -s <network_id2>:<initial_seeder> -s <network_id3>:<initial_seeder> -h tapyrusseed.example.com -n vps.example.com
+
+The initial seed node may be another Tapyrus seeder or a Tapyrus core node
+
+./tapyrusseed -i <network_id> -s <network_id>:<tapyrus_seeder_name> -s <network_id>:<ip_address>:<tapyrus_core_port>
 
 If you want the DNS server to report SOA records, please provide an
 e-mail address (with the @ part replaced by .) using -m.
@@ -43,9 +56,9 @@ COMPILING
 Compiling will require boost and ssl.  On debian systems, these are provided
 by `libboost-dev` and `libssl-dev` respectively.
 
-$ make
+$ make OPENSSL_PREFIX=/usr/local/opt/openssl
 
-This will produce the `dnsseed` binary.
+This will produce the `tapyrusseed` binary.
 
 
 RUNNING AS NON-ROOT
@@ -58,7 +71,7 @@ a non-privileged port:
 
 $ iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
 
-If properly configured, this will allow you to run dnsseed in userspace, using
+If properly configured, this will allow you to run tapyrusseed in userspace, using
 the -p 5353 option.
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <atomic>
+#include <iomanip>
 
 #include "tapyrus.h"
 #include "db.h"
@@ -17,6 +18,8 @@
 using namespace std;
 
 bool fTestNet = false;
+std::map<int, CAddrDb*> dbs;
+std::map<int, std::vector<std::string> > mSeeds;
 
 class CDnsSeedOpts {
 public:
@@ -34,6 +37,7 @@ public:
     const char *ipv6_proxy;
     std::set<uint64_t> filter_whitelist;
     std::vector<std::string> vSeeds;
+    std::set<int> networks;
 
     CDnsSeedOpts() : nThreads(96), nDnsThreads(4), nPort(53), mbox(NULL), ns(NULL), host(NULL), tor(NULL), fWipeBan(false), fWipeIgnore(false), ipv4_proxy(NULL), ipv6_proxy(NULL), networkid(1) {}
 
@@ -85,7 +89,7 @@ public:
             switch (c) {
                 case 'i': {
                     int n = strtol(optarg, NULL, 10);
-                    networkid = n;
+                    networks.emplace(n);
                     break;
                 }
 
@@ -178,8 +182,6 @@ public:
 };
 
 
-CAddrDb db;
-
 struct ThreadCrawler_options
 {
     int nThreads;
@@ -188,12 +190,14 @@ struct ThreadCrawler_options
 
 extern "C" void *ThreadCrawler(void *data) {
     ThreadCrawler_options *threadOpts = (ThreadCrawler_options*)data;
-    int nThreads = threadOpts->nThreads;
-    int nNetworkId = threadOpts->nNetworkId;
+    const int nThreads = threadOpts->nThreads;
+    const int nNetworkId = threadOpts->nNetworkId;
+    CAddrDb *db = dbs.find(nNetworkId)->second;
+
     do {
         std::vector<CServiceResult> ips;
         int wait = 5;
-        db.GetMany(ips, 16, wait);
+        db->GetMany(ips, 16, wait);
         int64 now = time(NULL);
         if (ips.empty()) {
             wait *= 1000;
@@ -212,8 +216,8 @@ extern "C" void *ThreadCrawler(void *data) {
             res.fGood = TestNode(res.service, res.nBanTime, res.nClientV, res.strClientV, res.nHeight,
                                  getaddr ? &addr : NULL, nNetworkId);
         }
-        db.ResultMany(ips);
-        db.Add(addr);
+        db->ResultMany(ips);
+        db->Add(addr);
     } while (1);
     return nullptr;
 }
@@ -233,11 +237,13 @@ public:
 
     dns_opt_t dns_opt; // must be first
     const int id;
+    const int network;
     std::map<uint64_t, FlagSpecificData> perflag;
     std::atomic<uint64_t> dbQueries;
     std::set<uint64_t> filterWhitelist;
 
     void cacheHit(uint64_t requestedFlags, bool force = false) {
+        CAddrDb *db = dbs.find(network)->second;
         static bool nets[NET_MAX] = {};
         if (!nets[NET_IPV4]) {
             nets[NET_IPV4] = true;
@@ -249,7 +255,7 @@ public:
         if (force || thisflag.cacheHits * 400 > (thisflag.cache.size() * thisflag.cache.size()) ||
             (thisflag.cacheHits * thisflag.cacheHits * 20 > thisflag.cache.size() && (now - thisflag.cacheTime > 5))) {
             set<CNetAddr> ips;
-            db.GetIPs(ips, requestedFlags, 1000, nets);
+            db->GetIPs(ips, requestedFlags, 1000, nets);
             dbQueries++;
             thisflag.cache.clear();
             thisflag.nIPv4 = 0;
@@ -277,7 +283,7 @@ public:
         }
     }
 
-    CDnsThread(CDnsSeedOpts *opts, int idIn) : id(idIn) {
+    CDnsThread(CDnsSeedOpts *opts, int idIn, int networkIn) : id(idIn), network(networkIn) {
         dns_opt.host = opts->host;
         dns_opt.ns = opts->ns;
         dns_opt.mbox = opts->mbox;
@@ -360,97 +366,149 @@ int StatCompare(const CAddrReport &a, const CAddrReport &b) {
 }
 
 extern "C" void *ThreadDumper(void *arg) {
-    int *pnetworkid = (int *)arg;
-    int count = 0;
-    char filename[25] = {};
-    sprintf(filename, "dnsseed.dat.%d", *pnetworkid);
+    std::set<int> *networks = (std::set<int> *)arg;
+
     do {
-        Sleep(100000 << count); // First 100s, than 200s, 400s, 800s, 1600s, and then 3200s forever
-        if (count < 5)
-            count++;
+
+        for(auto network:*networks)
         {
-            vector<CAddrReport> v = db.GetAll();
-            sort(v.begin(), v.end(), StatCompare);
-            FILE *f = fopen("dnsseed.dat.new", "w+");
-            if (f) {
-                {
-                    CAutoFile cf(f);
-                    cf << db;
+            CAddrDb *db = dbs.find(network)->second;
+            int count = 0;
+            char filename[25] = {};
+            sprintf(filename, "tapyrusseed.dat.%d", network);
+
+            Sleep(100000 << count); // First 100s, than 200s, 400s, 800s, 1600s, and then 3200s forever
+            if (count < 5)
+                count++;
+            {
+                vector<CAddrReport> v = db->GetAll();
+                sort(v.begin(), v.end(), StatCompare);
+                FILE *f = fopen("tapyrusseed.dat.new", "w+");
+                if (f) {
+                    {
+                        CAutoFile cf(f);
+                        cf << *db;
+                    }
+                    rename("tapyrusseed.dat.new", filename);
                 }
-                rename("dnsseed.dat.new", filename);
-            }
-            sprintf(filename, "dnsseed.dump.%d", *pnetworkid);
-            FILE *d = fopen(filename, "w");
-            fprintf(d,
-                    "# address                                        good  lastSuccess    %%(2h)   %%(8h)   %%(1d)   %%(7d)  %%(30d)  blocks      svcs  version\n");
-            double stat[5] = {0, 0, 0, 0, 0};
-            for (vector<CAddrReport>::const_iterator it = v.begin(); it < v.end(); it++) {
-                CAddrReport rep = *it;
+                sprintf(filename, "tapyrusseed.dump.%d", network);
+                FILE *d = fopen(filename, "w");
                 fprintf(d,
-                        "%-47s  %4d  %11" PRId64 "  %6.2f%% %6.2f%% %6.2f%% %6.2f%% %6.2f%%  %6i  %08" PRIx64 "  %5i \"%s\"\n",
-                        rep.ip.ToString().c_str(), (int) rep.fGood, rep.lastSuccess, 100.0 * rep.uptime[0],
-                        100.0 * rep.uptime[1], 100.0 * rep.uptime[2], 100.0 * rep.uptime[3], 100.0 * rep.uptime[4],
-                        rep.blocks, rep.services, rep.clientVersion, rep.clientSubVersion.c_str());
-                stat[0] += rep.uptime[0];
-                stat[1] += rep.uptime[1];
-                stat[2] += rep.uptime[2];
-                stat[3] += rep.uptime[3];
-                stat[4] += rep.uptime[4];
+                        "# address                                        good  lastSuccess    %%(2h)   %%(8h)   %%(1d)   %%(7d)  %%(30d)  blocks      svcs  version\n");
+                double stat[5] = {0, 0, 0, 0, 0};
+                for (vector<CAddrReport>::const_iterator it = v.begin(); it < v.end(); it++) {
+                    CAddrReport rep = *it;
+                    fprintf(d,
+                            "%-47s  %4d  %11" PRId64 "  %6.2f%% %6.2f%% %6.2f%% %6.2f%% %6.2f%%  %6i  %08" PRIx64 "  %5i \"%s\"\n",
+                            rep.ip.ToString().c_str(), (int) rep.fGood, rep.lastSuccess, 100.0 * rep.uptime[0],
+                            100.0 * rep.uptime[1], 100.0 * rep.uptime[2], 100.0 * rep.uptime[3], 100.0 * rep.uptime[4],
+                            rep.blocks, rep.services, rep.clientVersion, rep.clientSubVersion.c_str());
+                    stat[0] += rep.uptime[0];
+                    stat[1] += rep.uptime[1];
+                    stat[2] += rep.uptime[2];
+                    stat[3] += rep.uptime[3];
+                    stat[4] += rep.uptime[4];
+                }
+                fclose(d);
+                FILE *ff = fopen("tapyrusdnsstats.log", "a");
+                fprintf(ff, "%llu %g %g %g %g %g\n", (unsigned long long) (time(NULL)), stat[0], stat[1], stat[2], stat[3],
+                        stat[4]);
+                fclose(ff);
             }
-            fclose(d);
-            FILE *ff = fopen("dnsstats.log", "a");
-            fprintf(ff, "%llu %g %g %g %g %g\n", (unsigned long long) (time(NULL)), stat[0], stat[1], stat[2], stat[3],
-                    stat[4]);
-            fclose(ff);
         }
+
     } while (1);
     return nullptr;
 }
 
-extern "C" void *ThreadStats(void *) {
+extern "C" void *ThreadStats(void *arg) {
+    std::set<int> *networks = (std::set<int> *)arg;
+
     bool first = true;
     do {
         char c[256];
+        uint64_t requests = 0;
+        uint64_t queries = 0;
+        std::ostringstream displayStr;
+
         time_t tim = time(NULL);
         struct tm *tmp = localtime(&tim);
         strftime(c, 256, "[%y-%m-%d %H:%M:%S]", tmp);
-        CAddrDbStats stats;
-        db.GetStats(stats);
+
+        displayStr << std::setw(20) << c
+                   << std::setw(18) << "Elapsed time(s)"
+                   << std::setw(15) << "Network ID"
+                   << std::setw(11) << "Available"
+                   << std::setw(11) << "Tried"
+                   << std::setw(11) << "New"
+                   << std::setw(11) << "Active"
+                   << std::setw(11) << "Banned"
+                   << std::setw(15) << "DNS requests"
+                   << std::setw(15) << "db queries\n";
+
+        for(auto network:*networks)
+        {
+            CAddrDbStats stats;
+            CAddrDb *db = dbs.find(network)->second;
+            db->GetStats(stats);
+            requests = 0;
+            queries = 0;
+            for (unsigned int i = 0; i < dnsThread.size(); i++) {
+                requests += dnsThread[i]->dns_opt.nRequests;
+                queries += dnsThread[i]->dbQueries;
+            }
+            displayStr << std::setw(20) << ""
+                       << std::setw(18) << stats.nAge
+                       << std::setw(15) << network
+                       << std::setw(5) << stats.nGood << "/" << std::setw(5) << std::left << stats.nAvail
+                       << std::setw(11) << std::right << stats.nTracked
+                       << std::setw(11) << stats.nNew
+                       << std::setw(11) << stats.nAvail - stats.nTracked - stats.nNew
+                       << std::setw(11) << stats.nBanned
+                       << std::setw(15) << (unsigned long long) requests
+                       << std::setw(15) << (unsigned long long) queries
+                       << "\n";
+        }
         if (first) {
             first = false;
-            printf("\n\n\n\x1b[3A");
+            printf("\n\n\n\n\n\x1b[3A");
         } else
-            printf("\x1b[2K\x1b[u");
+            printf("\n\n\x1b[2K\x1b[u");
         printf("\x1b[s");
-        uint64_t requests = 0;
-        uint64_t queries = 0;
-        for (unsigned int i = 0; i < dnsThread.size(); i++) {
-            requests += dnsThread[i]->dns_opt.nRequests;
-            queries += dnsThread[i]->dbQueries;
-        }
-        printf("%s %i/%i available (%i tried in %is, %i new, %i active), %i banned; %llu DNS requests, %llu db queries\n",
-               c, stats.nGood, stats.nAvail, stats.nTracked, stats.nAge, stats.nNew,
-               stats.nAvail - stats.nTracked - stats.nNew, stats.nBanned, (unsigned long long) requests,
-               (unsigned long long) queries);
+        printf("%s", displayStr.str().c_str());
         Sleep(1000);
+
     } while (1);
     return nullptr;
 }
 
-extern "C" void *ThreadSeeder(void *seeds) {
-    const std::vector<std::string> *vSeeds = ( std::vector<std::string> *)seeds;
+struct ThreadSeeder_options
+{
+    std::map<int, std::vector<std::string> > *mSeeds;
+    int size;
+};
+
+extern "C" void *ThreadSeeder(void *args) {
+    ThreadSeeder_options* options = (ThreadSeeder_options*)args;
+    const std::map<int, std::vector<std::string> > *mSeeds = options->mSeeds;
+    const int size = options->size;
+
     vector<CNetAddr> ips;
     do {
-        for (auto& seed : *vSeeds) {
-            ips.clear();
-            auto pos = seed.find(':');
-            if(pos != std::string::npos)
-                db.Add(CService(seed), true);
-            else
-            {
-                LookupHost(seed.c_str(), ips);
-                for (vector<CNetAddr>::iterator it = ips.begin(); it != ips.end(); it++) {
-                    db.Add(CService(*it, TAPYRUS_DEFAULT_PORT), true);
+        for (auto &seedEnt:*mSeeds)
+        {
+            CAddrDb *db = dbs.find(seedEnt.first)->second;
+            for (auto& seed : seedEnt.second) {
+                ips.clear();
+                auto pos = seed.find(':');
+                if(pos != std::string::npos)
+                    db->Add(CService(seed), true);
+                else
+                {
+                    LookupHost(seed.c_str(), ips);
+                    for (vector<CNetAddr>::iterator it = ips.begin(); it != ips.end(); it++) {
+                        db->Add(CService(*it, TAPYRUS_DEFAULT_PORT), true);
+                    }
                 }
             }
         }
@@ -465,11 +523,6 @@ int main(int argc, char **argv) {
     CDnsSeedOpts opts;
     opts.ParseCommandLine(argc, argv);
     bool fDNS = true;
-
-    if (!opts.vSeeds.size()) {
-        printf("Dns seeder not set. Please use -s\n");
-        exit(1);
-    }
     if (!opts.ns) {
         printf("No nameserver set. Not starting DNS server.\n");
         fDNS = false;
@@ -483,15 +536,16 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
-    printf("Supporting whitelisted filters: ");
-    for (std::set<uint64_t>::const_iterator it = opts.filter_whitelist.begin();
-         it != opts.filter_whitelist.end(); it++) {
-        if (it != opts.filter_whitelist.begin()) {
-            printf(",");
-        }
-        printf("0x%lx", (unsigned long) *it);
-    }
-    printf("\n");
+    std::ostringstream  networkstr;
+    for(auto networkId:opts.networks)
+        networkstr << networkId << " ";
+    printf("Supporting networks : %s\n", networkstr.str().c_str());
+
+    std::ostringstream whitelistedstr;
+    for(auto flag:opts.filter_whitelist)
+        whitelistedstr << std::hex << "0x"<< flag << " ";
+    printf("Supporting whitelisted filters: %s\n", whitelistedstr.str().c_str());
+
     if (opts.tor) {
         CService service(opts.tor, 9050);
         if (service.IsValid()) {
@@ -513,53 +567,102 @@ int main(int argc, char **argv) {
             SetProxy(NET_IPV6, service);
         }
     }
-     printf("Dnsseed networkid is %i\n", opts.networkid);
 
-    char filename[25] = {};
-    sprintf(filename, "dnsseed.dat.%d", opts.networkid);
-    FILE *f = fopen(filename, "r");
-    if (f) {
-        printf("Loading %s...", filename);
-        CAutoFile cf(f);
-        cf >> db;
-        if (opts.fWipeBan)
-            db.banned.clear();
-        if (opts.fWipeIgnore)
-            db.ResetIgnores();
-        printf("done\n");
+    //parse opts.vSeeds and get the seeder name for each network.
+    std::vector<std::string> seedTmp;
+    for(auto network:opts.networks)
+    {
+        seedTmp.clear();
+        for(auto &seed:opts.vSeeds)
+        {
+            if(std::stoi(seed.substr(0, seed.find(":"))) == network)
+                seedTmp.push_back(seed.substr(seed.find(":")+1));
+        }
+        mSeeds.emplace(network, seedTmp);
     }
 
+    //find networks for which there is no seeder (-s).
+    std::set<int> missing;
+    for(auto network:opts.networks)
+        if(!mSeeds[network].size())
+            missing.emplace(network);
+
+    //initialize the DB for each network
+    for(auto network:opts.networks)
+        dbs[network] = new CAddrDb();
+
+    //load stats of networks for which there is no tapyrusseed.dat.
+    for(auto network: opts.networks)
+    {
+        char filename[25] = {};
+        sprintf(filename, "tapyrusseed.dat.%d", network);
+        FILE *f = fopen(filename, "r");
+        if (f) {
+            CAddrDb *db = dbs.find(network)->second;
+            printf("Loading %s...", filename);
+            CAutoFile cf(f);
+            cf >> *db;
+            if (opts.fWipeBan)
+                db->banned.clear();
+            if (opts.fWipeIgnore)
+                db->ResetIgnores();
+            printf("done\n");
+            missing.erase(network);
+        }
+    }
+
+    //if there are networks without tapyrusseed.dat and -s exit
+    if(missing.size()) {
+        printf("\nDNS information file, tapyrusseed.dat.<networkId> missing for some networks and number of initial DNS seeders do not match the number of networks served.\nPlease provide at least one -s <network_id>:<seeder_ip_address> for each of the networks configured using -i.\n");
+        exit(1);
+    }
 
     pthread_t threadDns, threadSeed, threadDump, threadStats;
+
+    printf("Starting seeder...");
+    ThreadSeeder_options threadOpts;
+    threadOpts.mSeeds = &mSeeds;
+    threadOpts.size = opts.networks.size();
+    pthread_create(&threadSeed, NULL, ThreadSeeder, &threadOpts);
+    printf("done\n");
+
+    int i = 0;
+    std::set<int>::iterator iter = opts.networks.begin();
     if (fDNS) {
         printf("Starting %i DNS threads for %s on %s (port %i)...", opts.nDnsThreads, opts.host, opts.ns, opts.nPort);
         dnsThread.clear();
-        for (int i = 0; i < opts.nDnsThreads; i++) {
-            dnsThread.push_back(new CDnsThread(&opts, i));
+        for (i = 0; i < opts.nDnsThreads; i++) {
+            dnsThread.push_back(new CDnsThread(&opts, i, *iter));
             pthread_create(&threadDns, NULL, ThreadDNS, dnsThread[i]);
+            ++iter;
+            if(iter == opts.networks.end())
+                iter = opts.networks.begin();
             printf(".");
             Sleep(20);
         }
         printf("done\n");
     }
-    printf("Starting seeder...");
-    pthread_create(&threadSeed, NULL, ThreadSeeder, &opts.vSeeds);
-    printf("done\n");
+
     printf("Starting %i crawler threads...", opts.nThreads);
     pthread_attr_t attr_crawler;
     pthread_attr_init(&attr_crawler);
     pthread_attr_setstacksize(&attr_crawler, 0x20000);
-    for (int i = 0; i < opts.nThreads; i++) {
+    iter = opts.networks.begin();
+    for (i = 0; i < opts.nThreads; i++) {
         pthread_t thread;
         ThreadCrawler_options threadOpts;
         threadOpts.nThreads = opts.nThreads;
-        threadOpts.nNetworkId = opts.networkid;
+        threadOpts.nNetworkId = *iter;
         pthread_create(&thread, &attr_crawler, ThreadCrawler, &threadOpts);
+        ++iter;
+        if(iter == opts.networks.end())
+            iter = opts.networks.begin();
     }
     pthread_attr_destroy(&attr_crawler);
     printf("done\n");
-    pthread_create(&threadStats, NULL, ThreadStats, NULL);
-    pthread_create(&threadDump, NULL, ThreadDumper, &opts.networkid);
+    pthread_create(&threadStats, NULL, ThreadStats, &opts.networks);
+    pthread_create(&threadDump, NULL, ThreadDumper, &opts.networks);
+    printf("Tapyrus Seeder Ready");
     void *res;
     pthread_join(threadDump, &res);
     return 0;

--- a/scripts/aws-linux/aws-linux-setup.sh
+++ b/scripts/aws-linux/aws-linux-setup.sh
@@ -8,11 +8,11 @@ git clone https://github.com/chaintope/tapyrus-seeder
 cd tapyrus-seeder
 
 #clearn
-rm -f dnsseed *.o
+rm -f tapyrusseed *.o
 
 # build
 make
 
 # install
-sudo cp ./dnsseed /usr/bin/dnsseed
+sudo cp ./tapyrusseed /usr/bin/tapyrusseed
 

--- a/scripts/aws-linux/launch.sh
+++ b/scripts/aws-linux/launch.sh
@@ -5,6 +5,8 @@ ZONEID=ZKAPA71BL90VS
 NSHOST=ns.tapyrus.dev.chaintope.com
 HOST=seed.tapyrus.dev.chaintope.com
 EMAIL=nakajo@chaintope.com
+NETWORK="-i1939510133"
+INIT_SEED="-s1939510133:seed.tapyrus.dev.chaintope.com"
 
 TTL=60
 NEWIP=`/usr/bin/curl -s "http://169.254.169.254/2008-02-01/meta-data/public-ipv4"`
@@ -18,4 +20,4 @@ screen -dmS seeder
 sleep 3s
 
 # launch seeder
-screen -S seeder -X -p 0 exec sudo dnsseed -h ${HOST} -n ${NSHOST} -m ${EMAIL} --testnet
+screen -S seeder -X -p 0 exec sudo tapyrusseed ${NETWORK} ${INIT_SEED} -h ${HOST} -n ${NSHOST} -m ${EMAIL} --testnet

--- a/scripts/ubuntu/launch.sh
+++ b/scripts/ubuntu/launch.sh
@@ -5,6 +5,8 @@ ZONEID=ZKAPA71BL90VS
 NSHOST=ns.tapyrus.dev.chaintope.com
 HOST=seed.tapyrus.dev.chaintope.com
 EMAIL=nakajo@chaintope.com
+NETWORK="-i1939510133"
+INIT_SEED="-s1939510133:seed.tapyrus.dev.chaintope.com"
 
 TTL=60
 NEWIP=`/usr/bin/curl -s "http://169.254.169.254/2008-02-01/meta-data/public-ipv4"`
@@ -19,4 +21,4 @@ screen -dmS seeder
 sleep 3s
 
 # launch seeder
-screen -S seeder -X -p 0 exec sudo dnsseed -h ${HOST} -n ${NSHOST} -m ${EMAIL} --testnet
+screen -S seeder -X -p 0 exec sudo tapyrusseed ${NETWORK} ${INIT_SEED} -h ${HOST} -n ${NSHOST} -m ${EMAIL} --testnet

--- a/scripts/ubuntu/ubuntu-setup.sh
+++ b/scripts/ubuntu/ubuntu-setup.sh
@@ -13,11 +13,11 @@ git clone https://github.com/chaintope/tapyrus-seeder
 cd tapyrus-seeder
 
 #clearn
-rm -f dnsseed *.o
+rm -f tapyrusseed *.o
 
 # build
 make
 
 # install
-sudo cp ./dnsseed /usr/bin/dnsseed
+sudo cp ./tapyrusseed /usr/bin/tapyrusseed
 


### PR DESCRIPTION
Added separate stats DB, CAddrDB, data files and log files for each serviced network.
Dumper, stats and seeder threads serve all networks, read and write the corresponding stats for each network.
At least one DNS seeder thread and one crawler thread serve each network. Network id is chosen in round-robin during the creation of threads.
Initial seed node -s is changed to use `-s <network_id>:<initial_seeder>` syntax to indicate the network id.
Renamed executable from dnsseed to tapyrusseed
Updated README and other config scripts. (Scripts are not tested.)